### PR TITLE
Remove `kma` dependency from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ classifiers = [
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = [
-    "pandas >= 1.5.0",
-    "kma >= 1.4.9",
+    "pandas >= 1.5.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Hi !

This PR removes the `kma` dependency from `pyproject.toml`. This array should only contain Python dependencies that will be downloaded from `pip`; there is a [`kma`](https://pypi.org/project/kma/) package on PyPI, however it's a package for Korean wheater forecast, so trying to install `salty` will fail at the moment.